### PR TITLE
Migrate to meson build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,35 @@ Izumi is an instruction pipeline visualizer for Onikiri2-Kanata format based on 
 - End of stage (for multiple cycle stages/stalling the pipeline)
 - End of instruction
 
+## Requierments
+
+- ncurses
+- meson (build only)
+- ninja (build only, can be replaced by other meson backends)
+
+## Building
+
+Building with `meson` is recommended:
+
+```bash
+meson setup build
+cd build
+meson compile
+```
+
+But, if the classic `make` sequence is hard-wired in your brain, you can:
+
+```bash
+./configure
+make
+```
+
+In both cases the binary will be found in `build/izumi`.
+
 ## Usage
 
 ```bash
-$ make
+$ cd build # if not done yet
 $ ./izumi <input_file> [-p]
 ```
 

--- a/configure
+++ b/configure
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# Get directories
+source_dir="$(dirname "$0")"
+source_dir="$(realpath "${source_dir}")"
+build_dir="${source_dir}/build"
+
+# Configure
+meson setup --reconfigure "$@" "${build_dir}" "${source_dir}"

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,14 @@
 project('Izumi', 'c',
   license: 'GPL-3.0-or-later',
   license_files: ['LICENSE'],
-  version: run_command('cut', 'src/version.h', '-d ', '-f3').stdout().strip().strip('"'),
+  version: '0.0.1',
+)
+
+conf_data = configuration_data()
+conf_data.set_quoted('VERSION', meson.project_version())
+configure_file(
+  output: 'config.h',
+  configuration: conf_data,
 )
 
 # Find a suitable shell

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,18 @@
+project('Izumi', 'c',
+  license: 'GPL-3.0-or-later',
+  license_files: ['LICENSE'],
+  version: run_command('cut', 'src/version.h', '-d ', '-f3').stdout().strip().strip('"'),
+)
+
+# Find a suitable shell
+shell = find_program('sh')
+
+# Locate sources
+sources_command = run_command(shell, '-c', 'echo src/*.c', check: true)
+sources = sources_command.stdout().strip().split(' ')
+
+# Locate ncurses
+ncurses = dependency('ncurses')
+
+# Define build targets
+executable('izumi', sources, dependencies: ncurses)

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,0 @@
-#define VERSION "0.0.1"

--- a/src/window.c
+++ b/src/window.c
@@ -22,7 +22,7 @@
 #include <sys/types.h>
 
 #include "window.h"
-#include "version.h"
+#include "config.h"
 
 void get_window_data(WindowData *data) {
     data->width = getmaxx(stdscr);


### PR DESCRIPTION
Use meson instead of a plain `Makefile` to improve manteinability. A dummy
`Makefile` and `configure` script that just call meson have been provided to
ease the transition. The header with metadata is now called `config.h` and it is
autogenerated. Version is now set in the `meson.build` file.

Note: Getting the version from the header is horrible and required using
commands that may not be available in all platforms. This can be seen on the
first commit.

I suggest this PR to be squashed before merging.
