### PR TITLE
fix freezing on retire by flush

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -182,10 +182,8 @@ void retire_instruction(InstructionTableArray *tables_array, u_int64_t cycle, ch
     // Get the instruction
     Instruction *instr = &tables_array->tables[instr_id/256]->content[instr_id%256];
 
-    if (type == 0) {
-        Stage *stage = &instr->stages[instr->qtty_stages - 1];
-        stage->duration = cycle - stage->cycle;
-    }    
+    Stage *stage = &instr->stages[instr->qtty_stages - 1];
+    stage->duration = cycle - stage->cycle;
 }
 
 


### PR DESCRIPTION
On the execution of the test input I am using I found a freezing on this point:
![image](https://github.com/user-attachments/assets/4f7a14e1-94a0-4688-b140-217bedd7921d)

Reading the data with the flag -p I could see this duration with no sense:
```
I	2370	0x00000000800010a0:	 addi    a5, a5, 32
	F1	 on 4033	duration: 1
	F2	 on 4034	duration: 11
	D	 on 4045	duration: 0
I	2371	(null)	(null)
	F1	 on 4034	duration: 11
	F2	 on 4045	duration: 0
I	2372	(null)	(null)
	F1	 on 4045	duration: 139496282319648
```

Which is caused by this input data:
```
C	1
I	2372	2372	0
S	2372	0	F1
E	2371	0	F1
S	2371	0	F2
L	2370	0	0x00000000800010a0: addi    a5, a5, 32
E	2370	0	F2
S	2370	0	D
E	2355	0	D
S	2355	0	I
E	2354	0	I
S	2354	0	R
E	2353	0	R
S	2353	0	B
R	2352	2352	0
C	1
R	2372	2372	1
```

Just by setting the duration for both kind of instruction retiring this issue is solved.