### PR TITLE
Fix nix builds using the flake url

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -4,11 +4,15 @@ on:
     branches: [main]
 
 jobs:
-  lints:
+  build_and_check:
     name: Build & Check
     runs-on: ubuntu-latest
+    env:
+      FLAKE_URL: ${{ format('github:{0}/{1}', github.repository, github.ref) }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - run: nix build . --print-build-logs
-      - run: nix flake check . --print-build-logs
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Build with nix
+        run: nix build $FLAKE_URL --print-build-logs
+      - name: Run nix checks
+        run: nix flake check $FLAKE_URL --print-build-logs

--- a/flake.lock
+++ b/flake.lock
@@ -63,17 +63,14 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1755674813,
-        "narHash": "sha256-Eq/PmLDYoVcMIjqf8TGKRaxbAGrrD6//G8fpH8Uhseg=",
-        "rev": "992994dad917d72b1a94c9f46cf09a04d5f3274b",
-        "revCount": 3,
-        "type": "git",
-        "url": "file:./izumi_tui"
+        "path": "izumi_tui",
+        "type": "path"
       },
       "original": {
-        "type": "git",
-        "url": "file:./izumi_tui"
-      }
+        "path": "izumi_tui",
+        "type": "path"
+      },
+      "parent": []
     },
     "libizumi": {
       "inputs": {
@@ -81,17 +78,14 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1755678060,
-        "narHash": "sha256-NYszSyZO7SAkMqaJSfsuEQXTm3Hxj+uodaSoV35Zrkk=",
-        "rev": "0f76c999717ba3ea6b3ce9d8f50931f6e9a04728",
-        "revCount": 3,
-        "type": "git",
-        "url": "file:./libizumi"
+        "path": "libizumi",
+        "type": "path"
       },
       "original": {
-        "type": "git",
-        "url": "file:./libizumi"
-      }
+        "path": "libizumi",
+        "type": "path"
+      },
+      "parent": []
     },
     "nixpkgs": {
       "locked": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
@@ -63,14 +63,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "path": "./izumi_tui",
-        "type": "path"
+        "lastModified": 1755674813,
+        "narHash": "sha256-Eq/PmLDYoVcMIjqf8TGKRaxbAGrrD6//G8fpH8Uhseg=",
+        "rev": "992994dad917d72b1a94c9f46cf09a04d5f3274b",
+        "revCount": 3,
+        "type": "git",
+        "url": "file:./izumi_tui"
       },
       "original": {
-        "path": "./izumi_tui",
-        "type": "path"
-      },
-      "parent": []
+        "type": "git",
+        "url": "file:./izumi_tui"
+      }
     },
     "libizumi": {
       "inputs": {
@@ -78,14 +81,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "path": "./libizumi",
-        "type": "path"
+        "lastModified": 1755678060,
+        "narHash": "sha256-NYszSyZO7SAkMqaJSfsuEQXTm3Hxj+uodaSoV35Zrkk=",
+        "rev": "0f76c999717ba3ea6b3ce9d8f50931f6e9a04728",
+        "revCount": 3,
+        "type": "git",
+        "url": "file:./libizumi"
       },
       "original": {
-        "path": "./libizumi",
-        "type": "path"
-      },
-      "parent": []
+        "type": "git",
+        "url": "file:./libizumi"
+      }
     },
     "nixpkgs": {
       "locked": {
@@ -105,11 +111,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
         "type": "github"
       },
       "original": {
@@ -166,11 +172,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1743538100,
-        "narHash": "sha256-Bl/ynRPIb4CdtbEw3gfJYpKiHmRmrKltXc8zipqpO0o=",
+        "lastModified": 1758416067,
+        "narHash": "sha256-knH+3x9P5s5iscG0yBO3Zp6NlG2wao9C7emmtnZcQC4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b9d43b3fe5152d1dc5783a2ba865b2a03388b741",
+        "rev": "51c8f9cfaae8306d135095bcdb3df9027f95542d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,8 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     
-    libizumi.url = "git+file:./libizumi";
-    izumi_tui.url = "git+file:./izumi_tui";
+    libizumi.url = ./libizumi;
+    izumi_tui.url = ./izumi_tui;
     izumi_tui.inputs.libizumi.follows = "libizumi";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,8 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     
-    libizumi.url = "path:./libizumi";
-    izumi_tui.url = "path:./izumi_tui";
+    libizumi.url = "git+file:./libizumi";
+    izumi_tui.url = "git+file:./izumi_tui";
     izumi_tui.inputs.libizumi.follows = "libizumi";
   };
 


### PR DESCRIPTION
An oversight on my part (and some nix store caching issues) lead to the nix flake not being buildable without using a local clone. In other words:
```sh
# This works:
git clone https://github.com/Izumi-visualizer/izumi
cd izumi
nix flake run .
# But this does not
nix flake run github:Izumi-visualizer/izumi
```

This PR fixes this, while modifying the CI to now run nix builds using the URL instead of a local clone, which should avoid issues likes this popping up again in the future.